### PR TITLE
Improve setup docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Variables de entorno requeridas
+OPENAI_API_KEY=tu_clave
+# Opcionales
+PROMPT_VERSION=v1_asistente_rrhh
+CHUNK_SIZE=512
+CHUNK_OVERLAP=50
+DATASET_PATH=tests/eval_dataset.json

--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ Este repositorio contiene el desarrollo completo del asistente **Endurance Lab A
 ✔ Reflexiones finales y criterio de claridad para usuarios deportistas
 
 -------------------------------------------------------
+⚙️ REQUISITOS BÁSICOS
+-------------------------------------------------------
+- Python 3.10 o superior
+- Copia `.env.example` a `.env` y agrega tu `OPENAI_API_KEY`
+
+-------------------------------------------------------
 🗂️ ESTRUCTURA DEL CONTENIDO
 -------------------------------------------------------
 
@@ -122,11 +128,12 @@ Resultados guardados como:
 
 1️⃣ Instalar dependencias:
    pip install -r requirements.txt
+2️⃣ Copiar `.env.example` a `.env` y definir tu clave de API
 
-2️⃣ Ejecutar la evaluación automática:
+3️⃣ Ejecutar la evaluación automática:
    python run_eval.py --dataset eval_dataset.csv
 
-3️⃣ Lanzar la aplicación Streamlit:
+4️⃣ Lanzar la aplicación Streamlit:
    streamlit run app/main_interface.py
 
 🌐 Luego, accede en tu navegador a:


### PR DESCRIPTION
## Summary
- add sample environment file
- document environment variables and Python version

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'mlflow')*

------
https://chatgpt.com/codex/tasks/task_e_68462ae0bcdc832582dd5f04518968a0